### PR TITLE
Fix to jasmine

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-jasmine": "~0.8.1",
+    "grunt-contrib-jasmine": "^1.1.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^0.6.0",

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     dist: {
       src: [
         'bower_components/chartist/dist/chartist.js',
-	'node_modules/chartist/dist/chartist.js',
+        'node_modules/chartist/dist/chartist.js',
         '<%= pkg.config.src %>/scripts/<%= pkg.config.src_name %>.js'
       ],
       options: {

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -14,6 +14,7 @@ module.exports = function (grunt) {
     dist: {
       src: [
         'bower_components/chartist/dist/chartist.js',
+				'node_modules/chartist/dist/chartist.js',
         '<%= pkg.config.src %>/scripts/<%= pkg.config.src_name %>.js'
       ],
       options: {

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     dist: {
       src: [
         'bower_components/chartist/dist/chartist.js',
-				'node_modules/chartist/dist/chartist.js',
+	'node_modules/chartist/dist/chartist.js',
         '<%= pkg.config.src %>/scripts/<%= pkg.config.src_name %>.js'
       ],
       options: {


### PR DESCRIPTION
Issue brought up in #107

The jasmine package was out of date, leading to an error. Also, if you installed chartist via npm it would not find the package for the jasmine test.