### PR TITLE
Fixed: last width/height values were being used

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -131,8 +131,8 @@
       });
 
       function setPosition(event) {
-        height = height || $toolTip.offsetHeight;
-        width = width || $toolTip.offsetWidth;
+        var height = height || $toolTip.offsetHeight;
+        var width = width || $toolTip.offsetWidth;
         var offsetX = - width / 2 + options.tooltipOffset.x
         var offsetY = - height + options.tooltipOffset.y;
         var anchorX, anchorY;


### PR DESCRIPTION
The last width/height values were being used by the setPosition function. This was an issue when there was a large tooltip in one of the values, leading to an error