### PR TITLE
Fixes width/height being incorrect

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -112,6 +112,11 @@
 
         if(tooltipText) {
           $toolTip.innerHTML = tooltipText;
+          
+          // Calculate new width and height, as toolTip width/height may have changed with innerHTML change
+          height = $toolTip.offsetHeight;
+          width = $toolTip.offsetWidth;
+          
           setPosition(event);
           show($toolTip);
 


### PR DESCRIPTION
When toolTip width/height changes due to the text being altered by the tooltipFnc.