### PR TITLE
Added index parameter to tooltip functions

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -68,13 +68,14 @@
         var meta = $point.getAttribute('ct:meta') || seriesName || '';
         var hasMeta = !!meta;
         var value = $point.getAttribute('ct:value');
+        var index = $point.getAttribute('ct:index');
 
         if (options.transformTooltipTextFnc && typeof options.transformTooltipTextFnc === 'function') {
-          value = options.transformTooltipTextFnc(value);
+          value = options.transformTooltipTextFnc(value, index);
         }
 
         if (options.tooltipFnc && typeof options.tooltipFnc === 'function') {
-          tooltipText = options.tooltipFnc(meta, value);
+          tooltipText = options.tooltipFnc(meta, value, index);
         } else {
           if (options.metaIsHTML) {
             var txt = document.createElement('textarea');


### PR DESCRIPTION
Sometimes I need to access the corresponding label in the ```transformTooltipTextFnc```.

###To get access to the index, add 'ct:index' in the draw event of the chart:
```chart.on('draw', e => {
    if (e.type == 'point') {
        e.element._node.setAttribute('ct:index', e.index);
    }
 });
```

Then the index can be accessed in the ```transformTooltipTextFnc(value, index)``` and the ```tooltipFnc(meta, value, index)``` and therefore the corresponding label => labels[index]