### PR TITLE
Fix for issue with tooltip top position

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -136,9 +136,10 @@
         var offsetX = - width / 2 + options.tooltipOffset.x
         var offsetY = - height + options.tooltipOffset.y;
         var anchorX, anchorY;
+        var offsetParent = $chart.offsetParent;
 
-        if (!options.appendToBody) {
-          var box = $chart.getBoundingClientRect();
+        if (!options.appendToBody && offsetParent != document.body) {
+          var box = offsetParent.getBoundingClientRect();
           var left = event.pageX - box.left - window.pageXOffset ;
           var top = event.pageY - box.top - window.pageYOffset ;
 


### PR DESCRIPTION
Fix problem with tool tip position when the chart container is statically positioned, and the tooltip option appendToBody has it's default (false) value.