### PR TITLE
Adding support for SOLID donut graphs

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -30,7 +30,8 @@
       } else if (chart.constructor.name ==  Chartist.Pie.prototype.constructor.name) {
         // Added support for donut graph
         if (chart.options.donut) {
-          tooltipSelector = 'ct-slice-donut';
+          // Added support or SOLID donut graph
+          tooltipSelector = chart.options.donutSolid ? 'ct-slice-donut-solid' : 'ct-slice-donut';
         } else {
           tooltipSelector = 'ct-slice-pie';
         }


### PR DESCRIPTION
This single-line fix aims to **add tooltip support for donut graphs** created with the `donutSolid:true` parameter.

Without this patch, the tooltip plugin only looks to SVG DOM elements having the _`'.ct-slice-donut'`_ class. The result is that the tooltip plugin actually fails to work, and is **not functional on solid Donut charts**.

As a chart created with the **'donutSolid:true'** parameter lead Chartist to assign the _**`'.ct-slice-donut-solid'`**_ class to the SVG DOM elements slices, it is therefore needed to perform an additional test in the tooltip plugin.

This patch will test if `chart.options.donutSolid` is `true`, and then define the `tooltipSelector` to _**`'.ct-slice-donut-solid'`**_ instead of _`'.ct-slice-donut'`_, which is relevant (and functional) only when `chart.options.donutSolid` is set to `false`.