### PR TITLE
Adding support for line charts.

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -25,7 +25,7 @@
 
     return function tooltip(chart) {
       var tooltipSelector = options.pointClass;
-      if (chart.constructor.name == Chartist.Bar.prototype.constructor.name) {
+      if (chart.options.stackMode) {
         tooltipSelector = 'ct-bar';
       } else if (chart.constructor.name ==  Chartist.Pie.prototype.constructor.name) {
         // Added support for donut graph


### PR DESCRIPTION
Chartist.Pie.prototype.constructor.name is "e", the same as Chartist.Line.prototype.constructor.name. Used another strategy to detect if the chart is a bar chart.